### PR TITLE
Поддержка Hugo 0.57.0+

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,0 +1,24 @@
+{{ define "main" }}
+
+<main>
+	{{ partial "index/introduction.html" . }}
+
+	<div class="catalogue">
+		{{ range (.Paginate .Site.RegularPages).Pages }}
+			{{ .Render "summary" }}
+		{{ end }}
+	</div>
+	
+	<div class="pagination">
+		{{ if .Paginator.HasPrev }}
+			<a href="{{ .Paginator.Prev.URL }}" class="left arrow">&#8592;</a>
+		{{ end }}
+		{{ if .Paginator.HasNext }}
+			<a href="{{ .Paginator.Next.URL }}" class="right arrow">&#8594;</a>
+		{{ end }}
+	
+		<span>{{ .Paginator.PageNumber }}</span>
+	</div>
+</main>
+
+{{ end }}


### PR DESCRIPTION
Начиная с [версии 0.57.0](https://gohugo.io/news/0.57.0-relnotes/#notes) Hugo поменял механизм работы директивы `.Pages`, что приводило к генерации невалидного сайта.

Я переопределил `layouts/index.html` внутри репозитория сайта, для поддержки новых версий Hugo.